### PR TITLE
Fix AttributeError on sched_getaffinity compatibility

### DIFF
--- a/features.py
+++ b/features.py
@@ -112,7 +112,10 @@ def main():
     features = pd.DataFrame(index=tids, columns=columns(), dtype=np.float32)
 
     # More than usable CPUs to be CPU bound, not I/O bound. Beware memory.
-    nb_workers = int(1.5 * len(os.sched_getaffinity(0)))
+    try:
+        nb_workers = int(1.5 * len(os.sched_getaffinity(0)))
+    except AttributeError as e:
+        nb_workers = 10
     print('Working with {} processes.'.format(nb_workers))
     pool = multiprocessing.Pool(nb_workers)
 


### PR DESCRIPTION
`sched_getaffinity` is only available on some Unix platforms as described in:
https://stackoverflow.com/questions/42538153/python-3-6-0-os-module-does-not-have-sched-getaffinity-method?answertab=votes#tab-top